### PR TITLE
Enable stacking of 0-dim arguments #3

### DIFF
--- a/src/StackViews.jl
+++ b/src/StackViews.jl
@@ -119,7 +119,7 @@ function Base.axes(A::StackView{T,N,D}) where {T,N,D}
     prev, post = Base.IteratorsMD.split(frame_axes, Val(D-1))
 
     # use homogenous range to make _append_tuple happy
-    fill_range = convert(typeof(first(frame_axes)), Base.OneTo(1))
+    fill_range = _convert(eltype(prev), Base.OneTo(1))
     return (_append_tuple(prev, Val(D-1), fill_range)...,
             Base.OneTo(length(A.slices)),
             post...)
@@ -140,6 +140,8 @@ end
 end
 
 # utils
+_convert(::Type{Base.Bottom}, idx)=idx
+_convert(T::Type, idx)=convert(T, idx)
 
 # For type stability
 @inline _max(::Val{x}, ::Val{y}) where {x, y} = Val(max(x, y))


### PR DESCRIPTION
I needed stacking to work with 0-dim objects.
This seems closely related to issue #3.
For me, however, the arguments to `StackView` really are array-like.
Julia's builtin `stack` can handle 0-dim objects.
With these small changes, the following code should work, too:
```julia
using StackViews

# 0-dim arrays
x = Array{Float64}(undef)
y = Array{Float64}(undef)

z = StackView(x, y)
z isa AbstractVector{Float64}   # true
z[1] = 1
z[2] = 2
z == [1, 2] # true

# 0-dim views
A = rand(2)
a1 = view(A, 1)
a2 = view(A, 2)
ndims(a1) == ndims(a2) == 0 # true
B = StackView(a1, a2)
B isa AbstractVector{Float64}   # true
B[1] = 1
B[2] = 2
B == A      # true, setting values in `B` affects views of `A`
B == [1, 2] # true

# Numbers 
# Numbers work (if given as `slices::Tuple`)
v = StackView((1, 2))
v isa AbstractVector{Int} # true
# setting values does not work! numbers are immutable!
# `Ref` does not work neither, issues with OffsetArrays
```